### PR TITLE
fix Psych::DisallowedClass error

### DIFF
--- a/panrun
+++ b/panrun
@@ -121,7 +121,7 @@ def get_meta_from_other_file(meta, type=nil)
                   nil
                 end
               end
-  file_meta, args = if file_name && m = YAML.load_file(file_name)
+  file_meta, args = if file_name && m = YAML.load_file(file_name, permitted_classes:["Date"])
                       [ m[output_key_name] || {}, ["--metadata-file", file_name] ]
                     else
                       [{}, []]
@@ -142,7 +142,7 @@ if input_file.nil? || input_file[0] == "-"
 end
 
 # load and merge various metadata
-yaml = YAML.load_file(input_file)
+yaml = YAML.load_file(input_file, permitted_classes:["Date"])
 doc_meta = yaml[output_key_name] || {}
 meta, file_arg = get_meta_from_other_file doc_meta, yaml["type"]
 


### PR DESCRIPTION
Fixes this error:

```
C:/tools/ruby33/lib/ruby/3.3.0/psych/class_loader.rb:99:in `find': Tried to load unspecified class: Date (Psych::DisallowedClass)
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/class_loader.rb:28:in `load'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/class_loader.rb:40:in `date'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/scalar_scanner.rb:66:in `tokenize'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/to_ruby.rb:65:in `deserialize'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/to_ruby.rb:130:in `visit_Psych_Nodes_Scalar'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/visitor.rb:30:in `visit'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/visitor.rb:6:in `accept'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/to_ruby.rb:35:in `accept'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/to_ruby.rb:347:in `block in revive_hash'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/to_ruby.rb:345:in `each'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/to_ruby.rb:345:in `each_slice'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/to_ruby.rb:345:in `revive_hash'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/to_ruby.rb:169:in `visit_Psych_Nodes_Mapping'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/visitor.rb:30:in `visit'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/visitor.rb:6:in `accept'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/to_ruby.rb:35:in `accept'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/to_ruby.rb:320:in `visit_Psych_Nodes_Document'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/visitor.rb:30:in `visit'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/visitor.rb:6:in `accept'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych/visitors/to_ruby.rb:35:in `accept'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych.rb:334:in `safe_load'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych.rb:369:in `load'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych.rb:671:in `block in load_file'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych.rb:670:in `open'
        from C:/tools/ruby33/lib/ruby/3.3.0/psych.rb:670:in `load_file'
        from C:/ProgramData/chocolatey/bin/panrun.rb:145:in `<main>'
```